### PR TITLE
Remove return outside method.

### DIFF
--- a/lib/best_in_place/check_version.rb
+++ b/lib/best_in_place/check_version.rb
@@ -2,7 +2,6 @@ module BestInPlace
   module CheckVersion
     if Rails::VERSION::STRING < "3.1"
       raise "This version of Best in Place is intended to be used for Rails >= 3.1. If you want to use it with Rails 3.0 or lower, please use the rails-3.0 branch."
-      return
     end
   end
 end


### PR DESCRIPTION
Remove return outside of the method. Ruby 2.6.3 is more strict and complains with syntax error.